### PR TITLE
Fix ES Module compatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hjmcp-stdio",
   "version": "1.0.0",
+  "type": "module",
   "description": "A simple MCP server using stdio transport",
   "main": "dist/server.js",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -344,7 +344,7 @@ Make the explanation clear and accessible.`,
   }
 }
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   const server = new MCPStdioServer();
   server.run().catch((error) => {
     console.error("Server error:", error);

--- a/src/simple-client.ts
+++ b/src/simple-client.ts
@@ -50,7 +50,7 @@ class SimpleTestClient {
   }
 }
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   const client = new SimpleTestClient();
   client.testServer();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
+    "module": "ES2022",
+    "moduleResolution": "node",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
- Update tsconfig.json to use ES2022 modules with node resolution
- Add 'type: module' to package.json for ES module support
- Replace require.main === module with import.meta.url equivalent
- Resolve ERR_REQUIRE_ESM error when running npm run test-simple
- All tests now pass successfully with proper MCP protocol communication